### PR TITLE
Feat: expense categories

### DIFF
--- a/app/actions/getTransactions.tsx
+++ b/app/actions/getTransactions.tsx
@@ -14,12 +14,22 @@ async function getTransactions(): Promise<{
   }
 
   try {
-    const transactions = await db.transaction.findMany({
+    const transactionsRaw = await db.transaction.findMany({
       where: { userId },
       orderBy: {
         createdAt: 'desc',
       },
     });
+
+    // Serialize dates to strings for transfer to client components
+    const transactions = transactionsRaw.map((t) => ({
+      id: t.id,
+      text: t.text,
+      amount: t.amount,
+      userId: t.userId,
+      category: (t as any).category ?? null,
+      createdAt: t.createdAt.toISOString(),
+    }));
 
     return { transactions };
   } catch (error) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -216,11 +216,68 @@ label {
 input[type='text'],
 input[type='number'] {
   border: 1px solid #dedede;
-  border-radius: 2px;
+  border-radius: 8px;
   display: block;
   font-size: 16px;
   padding: 10px;
   width: 100%;
+}
+
+select {
+  border: 1px solid #dedede;
+  border-radius: 8px;
+  padding: 10px;
+  font-size: 16px;
+  width: 100%;
+  background: #fff;
+}
+
+/* Category badge used in transaction items */
+.category-badge {
+  display: inline-block;
+  margin-top: 6px;
+  padding: 4px 8px;
+  background: rgba(0,0,0,0.06);
+  border-radius: 999px;
+  font-size: 12px;
+  color: #333;
+}
+
+/* Small chip next to the select to indicate selected category color */
+.filter-chip {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  display: inline-block;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+  border: 1px solid rgba(0,0,0,0.06);
+}
+
+/* Legend styling */
+.category-legend {
+  display: inline-flex;
+  gap: 10px;
+  align-items: center;
+  margin-left: 12px;
+}
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: rgba(0,0,0,0.02);
+}
+.legend-chip {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  display: inline-block;
+  border: 1px solid rgba(0,0,0,0.06);
+}
+.legend-label {
+  font-size: 12px;
+  color: rgba(0,0,0,0.7);
 }
 
 .btn {
@@ -234,7 +291,7 @@ input[type='number'] {
   margin: 10px 0 30px;
   padding: 12px 14px;
   width: 100%;
-  border-radius: 8px;
+  border-radius: 10px;
   transition: transform var(--btn-duration) var(--btn-ease), box-shadow var(--btn-duration) var(--btn-ease), background-color var(--btn-duration) var(--btn-ease), opacity var(--btn-duration) var(--btn-ease);
 }
 

--- a/components/AddTransaction.tsx
+++ b/components/AddTransaction.tsx
@@ -60,6 +60,16 @@ const AddTransaction = () => {
             disabled={isSubmitting}
           />
         </div>
+        <div className='form-control'>
+          <label htmlFor='category'>Category</label>
+          <input
+            type='text'
+            id='category'
+            name='category'
+            placeholder='e.g. Food, Travel, Utilities (optional)'
+            disabled={isSubmitting}
+          />
+        </div>
         <button className='btn' disabled={isSubmitting}>
           {isSubmitting ? (
             <>

--- a/components/AddTransaction.tsx
+++ b/components/AddTransaction.tsx
@@ -1,14 +1,17 @@
-'use client';
+ 'use client';
 import { useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import addTransaction from '@/app/actions/addTransaction';
 import { toast } from 'react-toastify';
 import Spinner from './Spinner';
+import CATEGORIES, { CATEGORY_COLORS } from '@/lib/categories';
 
 const AddTransaction = () => {
   const formRef = useRef<HTMLFormElement>(null);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [selectedCategory, setSelectedCategory] = useState<string>('');
+  const [customCategory, setCustomCategory] = useState<string>('');
 
   const clientAction = async (formData: FormData) => {
     setIsSubmitting(true);
@@ -62,13 +65,57 @@ const AddTransaction = () => {
         </div>
         <div className='form-control'>
           <label htmlFor='category'>Category</label>
-          <input
-            type='text'
+          <select
             id='category'
-            name='category'
-            placeholder='e.g. Food, Travel, Utilities (optional)'
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
             disabled={isSubmitting}
+          >
+            <option value=''>Select category (optional)</option>
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+            <option value='__other'>Other (custom)...</option>
+          </select>
+
+          {selectedCategory === '__other' ? (
+            <input
+              type='text'
+              id='category-custom'
+              placeholder='Enter custom category'
+              value={customCategory}
+              onChange={(e) => setCustomCategory(e.target.value)}
+              disabled={isSubmitting}
+              style={{ marginTop: 8 }}
+            />
+          ) : null}
+
+          {/* Hidden input holds the final category value submitted with the form */}
+          <input
+            type='hidden'
+            name='category'
+            value={
+              selectedCategory === ''
+                ? ''
+                : selectedCategory === '__other'
+                ? customCategory
+                : selectedCategory
+            }
           />
+          {/* Compact legend under the category select to show color hints */}
+          <div style={{ marginTop: 8 }} className='category-legend' aria-hidden>
+            {CATEGORIES.map((c) => (
+              <div key={c} className='legend-item' title={c}>
+                <span
+                  className='legend-chip'
+                  style={{ background: CATEGORY_COLORS[c] || 'rgba(0,0,0,0.12)' }}
+                />
+                <span className='legend-label'>{c}</span>
+              </div>
+            ))}
+          </div>
         </div>
         <button className='btn' disabled={isSubmitting}>
           {isSubmitting ? (

--- a/components/TransactionItem.tsx
+++ b/components/TransactionItem.tsx
@@ -5,6 +5,7 @@ import { addCommas } from '@/lib/utils';
 import { toast } from 'react-toastify';
 import deleteTransaction from '@/app/actions/deleteTransaction';
 import Spinner from './Spinner';
+import { CATEGORY_COLORS } from '@/lib/categories';
 
 const TransactionItem = ({ transaction }: { transaction: Transaction }) => {
   const sign = transaction.amount < 0 ? '-' : '+';
@@ -37,7 +38,25 @@ const TransactionItem = ({ transaction }: { transaction: Transaction }) => {
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <span>{transaction.text}</span>
         {transaction.category ? (
-          <small style={{ opacity: 0.8 }}>{transaction.category}</small>
+          <span
+            className='category-badge'
+            style={{
+              background: 'transparent',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: 999,
+                background: CATEGORY_COLORS[transaction.category] || 'rgba(0,0,0,0.12)'}}
+            />
+            <span style={{ fontSize: 12 }}>{transaction.category}</span>
+          </span>
         ) : null}
       </div>
       <span>

--- a/components/TransactionItem.tsx
+++ b/components/TransactionItem.tsx
@@ -34,7 +34,12 @@ const TransactionItem = ({ transaction }: { transaction: Transaction }) => {
 
   return (
     <li className={transaction.amount < 0 ? 'minus' : 'plus'}>
-      {transaction.text}
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <span>{transaction.text}</span>
+        {transaction.category ? (
+          <small style={{ opacity: 0.8 }}>{transaction.category}</small>
+        ) : null}
+      </div>
       <span>
         {sign}${addCommas(Math.abs(transaction.amount))}
       </span>

--- a/components/TransactionList.tsx
+++ b/components/TransactionList.tsx
@@ -1,6 +1,7 @@
-import getTransactions from '@/app/actions/getTransactions';
-import TransactionItem from './TransactionItem';
+import React from 'react';
+import TransactionListClient from './TransactionListClient';
 import { Transaction } from '@/types/Transaction';
+import getTransactions from '@/app/actions/getTransactions';
 
 const TransactionList = async () => {
   const { transactions, error } = await getTransactions();
@@ -12,12 +13,12 @@ const TransactionList = async () => {
   return (
     <>
       <h3>History</h3>
-      <ul className='list'>
-        {transactions &&
-          transactions.map((transaction: Transaction) => (
-            <TransactionItem key={transaction.id} transaction={transaction} />
-          ))}
-      </ul>
+      {transactions ? (
+        // Render a client component that can filter the list by category
+        <TransactionListClient transactions={transactions as Transaction[]} />
+      ) : (
+        <p>No transactions found</p>
+      )}
     </>
   );
 };

--- a/components/TransactionListClient.tsx
+++ b/components/TransactionListClient.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo, useState } from 'react';
 import { Transaction } from '@/types/Transaction';
 import TransactionItem from './TransactionItem';
+import CATEGORIES, { CATEGORY_COLORS } from '@/lib/categories';
 
 const ALL = 'All';
 
@@ -9,9 +10,10 @@ const TransactionListClient = ({ transactions }: { transactions: Transaction[] }
   const [selectedCategory, setSelectedCategory] = useState<string>(ALL);
 
   const categories = useMemo(() => {
-    const set = new Set<string>();
+    // Start with preset categories, then add any extra categories from transactions
+    const set = new Set<string>(CATEGORIES.filter(Boolean));
     transactions.forEach((t) => {
-      if (t.category) set.add(t.category);
+      if (t.category && !set.has(t.category)) set.add(t.category);
     });
     return [ALL, ...Array.from(set).sort()];
   }, [transactions]);
@@ -23,21 +25,49 @@ const TransactionListClient = ({ transactions }: { transactions: Transaction[] }
 
   return (
     <>
-      <div style={{ marginBottom: 12 }}>
+      <div style={{ marginBottom: 12 }} className='filter-row'>
         <label htmlFor='category-filter' style={{ marginRight: 8 }}>
           Filter by category:
         </label>
-        <select
-          id='category-filter'
-          value={selectedCategory}
-          onChange={(e) => setSelectedCategory(e.target.value)}
-        >
-          {categories.map((c) => (
-            <option key={c} value={c}>
-              {c}
-            </option>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <select
+            id='category-filter'
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+          >
+            {categories.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+
+          {/* show a small color chip for selected category (not coloring the whole select) */}
+          {selectedCategory && selectedCategory !== ALL ? (
+            <span
+              aria-hidden
+              className='filter-chip'
+              style={{
+                background: CATEGORY_COLORS[selectedCategory] || 'rgba(0,0,0,0.12)'
+              }}
+              title={selectedCategory}
+            />
+          ) : null}
+        </div>
+
+        {/* Legend: show preset categories with their colors in a compact row */}
+        <div style={{ marginLeft: 16 }} className='category-legend' aria-hidden>
+          {CATEGORIES.map((c) => (
+            <div key={c} className='legend-item' title={c}>
+              <span
+                className='legend-chip'
+                style={{ background: CATEGORY_COLORS[c] || 'rgba(0,0,0,0.12)' }}
+              />
+              <span className='legend-label'>{c}</span>
+            </div>
           ))}
-        </select>
+        </div>
       </div>
 
       <ul className='list'>

--- a/components/TransactionListClient.tsx
+++ b/components/TransactionListClient.tsx
@@ -1,0 +1,52 @@
+"use client";
+import React, { useMemo, useState } from 'react';
+import { Transaction } from '@/types/Transaction';
+import TransactionItem from './TransactionItem';
+
+const ALL = 'All';
+
+const TransactionListClient = ({ transactions }: { transactions: Transaction[] }) => {
+  const [selectedCategory, setSelectedCategory] = useState<string>(ALL);
+
+  const categories = useMemo(() => {
+    const set = new Set<string>();
+    transactions.forEach((t) => {
+      if (t.category) set.add(t.category);
+    });
+    return [ALL, ...Array.from(set).sort()];
+  }, [transactions]);
+
+  const filtered = useMemo(() => {
+    if (selectedCategory === ALL) return transactions;
+    return transactions.filter((t) => t.category === selectedCategory);
+  }, [transactions, selectedCategory]);
+
+  return (
+    <>
+      <div style={{ marginBottom: 12 }}>
+        <label htmlFor='category-filter' style={{ marginRight: 8 }}>
+          Filter by category:
+        </label>
+        <select
+          id='category-filter'
+          value={selectedCategory}
+          onChange={(e) => setSelectedCategory(e.target.value)}
+        >
+          {categories.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <ul className='list'>
+        {filtered.map((transaction) => (
+          <TransactionItem key={transaction.id} transaction={transaction} />
+        ))}
+      </ul>
+    </>
+  );
+};
+
+export default TransactionListClient;

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,24 @@
+// Configurable list of categories used across the app.
+// Modify this list to add/remove standard categories.
+export const CATEGORIES = [
+  'Food',
+  'Travel',
+  'Utilities',
+  'Entertainment',
+  'Shopping',
+  'Bills',
+  'Health',
+];
+
+// Color map for categories. Tweak colors here to change palette across the app.
+export const CATEGORY_COLORS: Record<string, string> = {
+  Food: '#f39c12', // orange
+  Travel: '#3498db', // blue
+  Utilities: '#9b59b6', // purple
+  Entertainment: '#e67e22', // orange-dark
+  Shopping: '#e84393', // pink
+  Bills: '#2ecc71', // green
+  Health: '#1abc9c', // teal
+};
+
+export default CATEGORIES;

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,7 +580,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.4.tgz",
       "integrity": "sha512-R8/V7vugY+822rsQGQCjoLhMuC9oFj9SOi4Cl4b2wjDrseD0LRZ10W7R6Czo4w9ZznVSshKjuIomsRjvm9EKJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.4",
         "@swc/helpers": "0.5.5",
@@ -683,7 +682,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.15.1"
       },
@@ -699,7 +697,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -712,7 +709,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"

--- a/prisma/migrations/20251004185315_add_category_to_transaction/migration.sql
+++ b/prisma/migrations/20251004185315_add_category_to_transaction/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Transaction" ADD COLUMN     "category" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,8 @@ model Transaction {
   id  String @id @default(uuid())
   text  String
   amount  Float
+  // Category for the transaction (e.g. Food, Travel, Utilities)
+  category String?
   // Relation to user
   userId  String
   user User @relation(fields: [userId], references: [clerkUserId], onDelete: Cascade)

--- a/types/Transaction.ts
+++ b/types/Transaction.ts
@@ -3,5 +3,6 @@ export interface Transaction {
   text: string;
   amount: number;
   userId: string;
-  createdAt: Date;
+  category?: string | null;
+  createdAt: string;
 }


### PR DESCRIPTION
### **What this PR does**

Fixes: #14 
- Adds an optional category field to transactions and persists it on create.
- Replaces free-text category input with a preset select + “Other (custom)” option and optional custom text input.
- Adds a client-side category filter in History (no extra server calls).
- Shows color-coded badges beside transactions and a small color legend near category controls to hint which color maps to each preset category.
- Introduces categories.ts for a configurable preset list and color palette.
- Minor styling improvements to inputs, buttons and badges for a more modern look.

### Screenshots
<img width="1121" height="556" alt="image" src="https://github.com/user-attachments/assets/823d4dc3-0a07-4276-b581-587f8731d840" />


Files changed (high level)

- schema.prisma — add category String? to Transaction
- Transaction.ts — include category?: string | null and createdAt serialized as string
- addTransaction.ts — accept and persist category
- getTransactions.tsx — return category and serialize createdAt
- AddTransaction.tsx — preset category select + custom option + legend
- TransactionList.tsx — server fetch + render client list
- TransactionListClient.tsx — client filter & color chip
- TransactionItem.tsx — colored category badge
- categories.ts — preset categories and CATEGORY_COLORS
- globals.css — styles for badges, legend and inputs

**Database migration (required)** This PR modifies the Prisma schema. After pulling, run locally:
```

npx prisma migrate dev --name add-category-to-transaction
npx prisma generate
```

For production:
```
npx prisma migrate deploy
npx prisma generate
```

How to test / QA


1. Install & run:
```
npm install
npm run dev
```
2. Add transactions:
-  Use the Add transaction form. Choose a preset category (e.g., “Food”) or choose “Other (custom)” and enter a custom category.
- Confirm the new transaction shows in History and displays a colored badge.

5. Filter:
- Use the “Filter by category” dropdown in History. Confirm only transactions with the selected category appear. “All” shows everything.
7. Visual hints:
- Confirm the compact color legend appears next to the Category select and that badges use matching colors.
9. Edge cases:
- Transactions without a category still list correctly.
-  Custom categories are accepted and filterable (they won’t be shown in preset legend until added to categories.ts).

Notes & compatibility

- The category field is optional; existing data is preserved.
- The server action uses a dynamic data object to avoid transient TypeScript errors until you run prisma generate.
- Preset categories + colors live in categories.ts so they can be updated centrally.

Checklist

- [x]  DB schema updated (migration notes included)
- [x]  Add transaction uses preset category selector + custom option
- [x]  Categories persist and display as colored badges
- [x]  History can be filtered client-side by category
- [x]  Compact legend / color hint added near controls
- [x]  Basic modernized styling applied